### PR TITLE
Mejorar estilo y orden cronológico en secciones

### DIFF
--- a/src/app/componentes/educacion/educacion.component.html
+++ b/src/app/componentes/educacion/educacion.component.html
@@ -1,21 +1,26 @@
 <!-- Empieza la sección eduación -->
 <section id="educacion" class="educacion">
-    <div class="container text-center seccion">
-        <h2><span class="text-secondary">Educación</span></h2>
-        <div class="row d-flex justify-content-center align-items-center"  *ngFor="let estudio of estudios">
-            <div class="col-10 col-sm-8 col-md-4">
-                <img src="{{estudio.imgCurso}}" class="rounded-circle w-75" alt="..." tittle="...">
-                <h2><span class="text-secondary">{{estudio.tituloCurso}}</span></h2>
-                <h2><span class="text-secondary">{{estudio.institucion}}</span></h2>
-                <h2><span class="text-secondary">{{estudio.anio}}</span></h2>
-                <br>
-            </div>
-            <div class="col-10 col-sm-8 col-md-8">
-                <h5><span class="text-secondary">{{estudio.descripcionEducacion}}
-                </span></h5>
-            </div>
-        </div>
+  <div class="container seccion section-shell">
+    <div class="section-header">
+      <p class="eyebrow">Educación</p>
+      <h2>Formación académica</h2>
+      <p class="section-subtitle">Últimos estudios primero</p>
     </div>
+    <div class="row g-4">
+      <div class="col-12" *ngFor="let estudio of estudios">
+        <div class="experience-card">
+          <div class="experience-meta">
+            <img src="{{estudio.imgCurso}}" class="company-logo" alt="Logo institución">
+            <div>
+              <h3>{{estudio.tituloCurso}}</h3>
+              <p class="text-muted">{{estudio.institucion}} • {{estudio.anio}}</p>
+            </div>
+          </div>
+          <p class="experience-description">{{estudio.descripcionEducacion}}</p>
+        </div>
+      </div>
+    </div>
+  </div>
 </section>
 
 <br><br>

--- a/src/app/componentes/educacion/educacion.component.ts
+++ b/src/app/componentes/educacion/educacion.component.ts
@@ -21,6 +21,8 @@ export class EducacionComponent implements OnInit {
   //llamamos a los métodos
 
   public cargarEstudio():void{   //no va a haber ningun retorno, solo una carga de datos
-    this.sEstudio.verEducacion().subscribe(data => {this.estudios=data}); // uso el this porque esta fuera del método
+    this.sEstudio.verEducacion().subscribe(data => {
+      this.estudios = data.slice().reverse();
+    }); // uso el this porque esta fuera del método
   }
 }

--- a/src/app/componentes/experiencia/experiencia.component.css
+++ b/src/app/componentes/experiencia/experiencia.component.css
@@ -1,0 +1,3 @@
+section#experiencia {
+  padding: 3rem 0 1rem;
+}

--- a/src/app/componentes/experiencia/experiencia.component.html
+++ b/src/app/componentes/experiencia/experiencia.component.html
@@ -1,21 +1,26 @@
 <!-- Empieza la sección experiencia -->
 <section id="experiencia" class="experiencia">
-    <div class="container text-center seccion">
-        <h2><span class="text-secondary">Experiencia</span></h2>
-        <div class="row d-flex justify-content-center align-items-center"  *ngFor="let experiencia of experiencias">
-            <div class="col-10 col-sm-8 col-md-4">
-                <img src="{{experiencia.imgExperiencia}}" class="rounded-circle w-75" alt="..." tittle="...">
-                <h2><span class="text-secondary">{{experiencia.puesto}}</span></h2>
-                <h2><span class="text-secondary">{{experiencia.empresa}}</span></h2>
-                <h2><span class="text-secondary">{{experiencia.anio}}</span></h2>
-                <br>
-            </div>
-            <div class="col-10 col-sm-8 col-md-8">
-                <h5><span class="text-secondary">{{experiencia.descripcionTrabajo}}
-                </span></h5>
-            </div>
-        </div>
+  <div class="container seccion section-shell">
+    <div class="section-header">
+      <p class="eyebrow">Experiencia</p>
+      <h2>Trayectoria profesional</h2>
+      <p class="section-subtitle">Últimas experiencias primero</p>
     </div>
+    <div class="row g-4">
+      <div class="col-12" *ngFor="let experiencia of experiencias">
+        <div class="experience-card">
+          <div class="experience-meta">
+            <img src="{{experiencia.imgExperiencia}}" class="company-logo" alt="Logo empresa">
+            <div>
+              <h3>{{experiencia.puesto}}</h3>
+              <p class="text-muted">{{experiencia.empresa}} • {{experiencia.anio}}</p>
+            </div>
+          </div>
+          <p class="experience-description">{{experiencia.descripcionTrabajo}}</p>
+        </div>
+      </div>
+    </div>
+  </div>
 </section>
 
 <br><br>

--- a/src/app/componentes/experiencia/experiencia.component.ts
+++ b/src/app/componentes/experiencia/experiencia.component.ts
@@ -20,7 +20,9 @@ export class ExperienciaComponent implements OnInit {
   //llamamos a los métodos
 
   public cargarExperiencia():void{   //no va a haber ningun retorno, solo una carga de datos
-    this.sExperiencia.verExperiencias().subscribe(data => {this.experiencias=data}); // uso el this porque esta fuera del método
+    this.sExperiencia.verExperiencias().subscribe(data => {
+      this.experiencias = data.slice().reverse();
+    }); // uso el this porque esta fuera del método
   }
 
   public borrar(id:number){
@@ -35,18 +37,4 @@ export class ExperienciaComponent implements OnInit {
       )
     }
   }
-
-  public  (id:number){
-    if(id != undefined){
-      this.sExperiencia.borrarExperiencia(id).subscribe(
-        data =>{
-          // alert("Experiencia eliminada correctamente)
-          this.cargarExperiencia();
-        }, err =>{
-          alert("No se pudo elmiminar la experiencia")
-        }
-      )
-    }
-  }
-
 }

--- a/src/app/componentes/habilidades/habilidades.component.css
+++ b/src/app/componentes/habilidades/habilidades.component.css
@@ -1,0 +1,45 @@
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.skill-chip {
+  background: #fff;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(37, 99, 235, 0.08);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.skill-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.skill-name {
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.skill-percentage {
+  font-weight: 600;
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.1);
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.progress {
+  height: 8px;
+  background-color: #e5e7eb;
+  border-radius: 999px;
+}
+
+.progress-bar {
+  background-color: #2563eb;
+  border-radius: 999px;
+}

--- a/src/app/componentes/habilidades/habilidades.component.html
+++ b/src/app/componentes/habilidades/habilidades.component.html
@@ -1,17 +1,24 @@
 <!-- Empieza la sección habilidades -->
 <section id="habilidades" class="habilidades">
-    <div class="container text-center seccion">
-        <h2><span class="text-secondary">Habilidades</span></h2>
-        <div class="row d-flex justify-content-center align-items-center">
-            <div class="progress mb-3 col-12 col-sm-10 col-md-8" *ngFor="let habilidad of habilidades">
-                <div class="progress-bar progress-bar-striped" role="progressbar" aria-label="Default striped example"
-                    aria-valuenow="10" aria-valuemin="0" aria-valuemax="100" [style.width.%]="habilidad.porcentaje">
-                    {{habilidad.porcentaje}}% de {{habilidad.nombre}} Completo
-                </div>
-            </div>
-        </div>
+  <div class="container seccion section-shell">
+    <div class="section-header">
+      <p class="eyebrow">Habilidades</p>
+      <h2>Herramientas y tecnologías</h2>
+      <p class="section-subtitle">Últimas habilidades agregadas primero</p>
     </div>
-
-
+    <div class="skills-grid" *ngIf="habilidades?.length">
+      <div class="skill-chip" *ngFor="let habilidad of habilidades">
+        <div class="skill-header">
+          <span class="skill-name">{{habilidad.nombre}}</span>
+          <span class="skill-percentage">{{habilidad.porcentaje}}%</span>
+        </div>
+        <div class="progress">
+          <div class="progress-bar" role="progressbar" aria-label="Avance"
+            aria-valuemin="0" aria-valuemax="100" [style.width.%]="habilidad.porcentaje">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </section>
 <br><br>

--- a/src/app/componentes/habilidades/habilidades.component.ts
+++ b/src/app/componentes/habilidades/habilidades.component.ts
@@ -20,7 +20,9 @@ export class HabilidadesComponent implements OnInit {
   //llamamos a los métodos
 
   public cargarHabilidad():void{   //no va a haber ningun retorno, solo una carga de datos
-    this.sHabilidad.verHabilidades().subscribe(data => {this.habilidades=data}); // uso el this porque esta fuera del método
+    this.sHabilidad.verHabilidades().subscribe(data => {
+      this.habilidades = data.slice().reverse();
+    }); // uso el this porque esta fuera del método
   }
 
 }

--- a/src/app/componentes/proyecto/proyecto.component.css
+++ b/src/app/componentes/proyecto/proyecto.component.css
@@ -1,0 +1,11 @@
+.project-card .btn {
+  align-self: flex-start;
+  border-radius: 12px;
+  padding-inline: 1.2rem;
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+}
+
+.project-footer {
+  display: flex;
+  justify-content: flex-start;
+}

--- a/src/app/componentes/proyecto/proyecto.component.html
+++ b/src/app/componentes/proyecto/proyecto.component.html
@@ -1,21 +1,29 @@
 <!-- Empieza la sección proyecto -->
 <section id="proyecto" class="proyecto">
-    <div class="container text-center seccion">
-        <h2><span class="text-secondary">Proyecto</span></h2>
-        <div class="row d-flex justify-content-center align-items-center"  *ngFor="let proyecto of proyectos">
-            <div class="col-10 col-sm-8 col-md-4">
-                <img src="{{proyecto.imgProyecto}}" class="rounded-circle w-75" alt="..." tittle="...">
-                <h2><span class="text-secondary">{{proyecto.nombreProyecto}}</span></h2>
-                <h2><span class="text-secondary">{{proyecto.institucion}}</span></h2>
-                <h2><span class="text-secondary">{{proyecto.anio}}</span></h2>
-                <br>
-            </div>
-            <div class="col-10 col-sm-8 col-md-8">
-                <h5><span class="text-secondary">{{proyecto.descripcionProyecto}}</span></h5>
-                <a target="_blank" type="button" class="btn btn-primary" href="{{proyecto.linkProyecto}}">Repositorio GitHub</a>
-            </div>
-        </div>
+  <div class="container seccion section-shell">
+    <div class="section-header">
+      <p class="eyebrow">Proyectos</p>
+      <h2>Portafolio reciente</h2>
+      <p class="section-subtitle">Últimos proyectos primero</p>
     </div>
+    <div class="row g-4">
+      <div class="col-12" *ngFor="let proyecto of proyectos">
+        <div class="experience-card project-card">
+          <div class="experience-meta">
+            <img src="{{proyecto.imgProyecto}}" class="company-logo" alt="Imagen del proyecto">
+            <div>
+              <h3>{{proyecto.nombreProyecto}}</h3>
+              <p class="text-muted">{{proyecto.institucion}} • {{proyecto.anio}}</p>
+            </div>
+          </div>
+          <p class="experience-description">{{proyecto.descripcionProyecto}}</p>
+          <div class="project-footer">
+            <a target="_blank" type="button" class="btn btn-primary" href="{{proyecto.linkProyecto}}">Repositorio GitHub</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </section>
 
 <br><br>

--- a/src/app/componentes/proyecto/proyecto.component.ts
+++ b/src/app/componentes/proyecto/proyecto.component.ts
@@ -20,7 +20,9 @@ export class ProyectoComponent implements OnInit {
   //llamamos a los métodos
 
   public cargarProyecto():void{   //no va a haber ningun retorno, solo una carga de datos
-    this.sProyecto.verProyectos().subscribe(data => {this.proyectos=data}); // uso el this porque esta fuera del método
+    this.sProyecto.verProyectos().subscribe(data => {
+      this.proyectos = data.slice().reverse();
+    }); // uso el this porque esta fuera del método
   }
 
 }

--- a/src/app/componentes/sobre-mi/sobre-mi.component.css
+++ b/src/app/componentes/sobre-mi/sobre-mi.component.css
@@ -1,0 +1,58 @@
+.about-shell {
+  background: linear-gradient(145deg, #fff, #f4f6fb);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(37, 99, 235, 0.08);
+  border-radius: 28px;
+  padding: 2.5rem 2rem;
+}
+
+.avatar-wrapper {
+  width: 180px;
+  height: 180px;
+  margin: 0 auto 1rem;
+  border-radius: 50%;
+  padding: 8px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(16, 185, 129, 0.18));
+  display: grid;
+  place-items: center;
+  box-shadow: 0 14px 32px rgba(37, 99, 235, 0.16);
+}
+
+.avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid #fff;
+}
+
+.about-name {
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: #111827;
+  margin: 0;
+}
+
+.about-title {
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 0.5rem;
+}
+
+.about-description {
+  color: #334155;
+  line-height: 1.7;
+  font-size: 1.02rem;
+  margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+  .about-shell {
+    padding: 1.75rem 1.25rem;
+  }
+
+  .avatar-wrapper {
+    width: 150px;
+    height: 150px;
+  }
+}

--- a/src/app/componentes/sobre-mi/sobre-mi.component.html
+++ b/src/app/componentes/sobre-mi/sobre-mi.component.html
@@ -1,20 +1,21 @@
 <!-- Empieza la sección sobre mí -->
 <section id="sobre_mi">
-    <div class="container text-center">
-        <div class="row d-flex justify-content-center align-items-center"  *ngFor="let persona of personas">
-
-            <div class="col-10 col-sm-8 col-md-4">
-                <img src="{{persona.imgPerfil}}" class="rounded-circle w-75" alt="foto de perfil" tittle="...">
-                <h2><span class="text-secondary">{{persona.nombre}} {{persona.apellido}}</span></h2>
-                <!-- <h2><span class="text-secondary">Apellido: {{persona.apellido}}</span></h2> -->
-                <h2><span class="text-secondary">Edad: {{persona.edad}} años</span></h2>
-            </div>
-            <div class="col-10 col-sm-8 col-md-8">
-                <h5><span class="text-secondary">{{persona.acercaDe}}
-                </span></h5>
-            </div>
+  <div class="container seccion section-shell about-shell" *ngFor="let persona of personas">
+    <div class="row align-items-center g-4">
+      <div class="col-12 col-md-4 text-center">
+        <div class="avatar-wrapper">
+          <img src="{{persona.imgPerfil}}" class="avatar" alt="foto de perfil">
         </div>
+        <h2 class="about-name">{{persona.nombre}} {{persona.apellido}}</h2>
+        <p class="text-muted">Edad: {{persona.edad}} años</p>
+      </div>
+      <div class="col-12 col-md-8">
+        <p class="eyebrow">Sobre mí</p>
+        <h3 class="about-title">Conoce quién está detrás del proyecto</h3>
+        <p class="about-description">{{persona.acercaDe}}</p>
+      </div>
     </div>
+  </div>
 </section>
 
 <br><br>

--- a/src/app/componentes/sobre-mi/sobre-mi.component.ts
+++ b/src/app/componentes/sobre-mi/sobre-mi.component.ts
@@ -21,7 +21,9 @@ export class SobreMiComponent implements OnInit {
   }
 
   lista():void{
-    this.sPersona.verPersonas().subscribe(data => {this.personas=data});
+    this.sPersona.verPersonas().subscribe(data => {
+      this.personas = data.slice().reverse();
+    });
   }
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,13 +6,115 @@
 }
 
 body {
-    background-color:rgba(19, 179, 219, 0.24);
+    background: radial-gradient(circle at 20% 20%, rgba(37,99,235,0.08), transparent 35%),
+                radial-gradient(circle at 80% 0%, rgba(16,185,129,0.06), transparent 30%),
+                #f5f7fb;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: #0f172a;
 }
 
 div.seccion{
-    background-color: rgba(255, 0, 64, 0.13);
+    background-color: transparent;
 }
 
 section[id]{
     scroll-margin-top: 8.8rem;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    letter-spacing: -0.02em;
+}
+
+.section-shell {
+    background: linear-gradient(135deg, #f7f9fb, #eef2f7);
+    border-radius: 28px;
+    padding: 2.5rem 2rem;
+    box-shadow: 0 14px 40px rgba(15, 23, 42, 0.12);
+    border: 1px solid rgba(37, 99, 235, 0.08);
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+.section-header h2 {
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: #1f2937;
+    margin: 0.25rem 0;
+}
+
+.section-subtitle {
+    color: #6b7280;
+    margin-top: 0.25rem;
+    font-size: 0.95rem;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    letter-spacing: 0.18em;
+    color: #2563eb;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+
+.experience-card {
+    background: #fff;
+    border-radius: 20px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(37, 99, 235, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.experience-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
+}
+
+.experience-meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.company-logo {
+    width: 68px;
+    height: 68px;
+    border-radius: 18px;
+    object-fit: cover;
+    background: #eef2f7;
+    border: 1px solid rgba(37, 99, 235, 0.08);
+    box-shadow: inset 0 2px 6px rgba(0,0,0,0.06);
+}
+
+.text-muted {
+    color: #6b7280;
+    margin: 0.15rem 0 0;
+}
+
+.experience-description {
+    margin: 0;
+    color: #334155;
+    line-height: 1.6;
+}
+
+@media (max-width: 768px) {
+    .section-shell {
+        padding: 1.75rem 1.25rem;
+    }
+
+    .experience-card {
+        padding: 1.25rem;
+    }
+
+    .company-logo {
+        width: 60px;
+        height: 60px;
+    }
 }


### PR DESCRIPTION
## Summary
- Rediseñar las secciones de experiencia, educación, habilidades y proyectos con tarjetas redondeadas y layout más limpio
- Invertir el orden de los listados para mostrar primero los elementos más recientes
- Aplicar mejoras visuales globales, incluyendo fondos suaves y tipografía más moderna, además de un bloque destacado para la sección Sobre mí

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959732eab288326b2eab13b84372576)